### PR TITLE
Fix file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ caplog "Some entry text"
 ## Log history
 
 Logs are created by default under `$HOME/.caplog/capbook`, which is initialized as a git repository.
-The logs are written directly to main branch following `<timestamp>_<hash>.log` pattern.
+The logs are written directly to main branch following `<day>-<month>-<year>.log.md` pattern.
 After file is created it will automatically be committed to the `.caplog/capbook` repository.
 
 The default location can be changed to any preferred location. It can also be an existing git repository.
@@ -59,20 +59,22 @@ NOTE: if using existing git repository, currently the logs will always be added 
 Created logs are in human readable text format.
 The writer has all the freedom of composing the message.
 
+The logs can be easily read with markdown viewers like `glow`.
+
 ```log
-// 2022-05-16T19:20:17_49b13c5.log
+// 16-05-2022.log.md
 ---
 date: Monday, May 16, 2022
 ---
 
 19:20	Hello this is my first log entry!
 
-Used as an example to provide some idea of the log entry.
+	Used as an example to provide some idea of the log entry.
 
-You can write anything here and even use keywords or tags
-to provide easier content seeking capabilities.
+	You can write anything here and even use keywords or tags
+	to provide easier content seeking capabilities.
 
-tags: example, caplog
+	tags: example, caplog
 ```
 
 #### Tagging

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -55,12 +55,7 @@ func TestFormatLog(t *testing.T) {
 		},
 		{
 			log: Log{Meta: Meta{Date: testDate}, Data: []string{"New log entry"}},
-			expected: `---
-date: Saturday, May 14, 2022
----
-
-22:34	New log entry
-`,
+			expected: "22:34	New log entry\n",
 		},
 		{
 			log: Log{Meta: Meta{Date: testDate, Page: "test"}, Data: []string{
@@ -68,15 +63,9 @@ date: Saturday, May 14, 2022
 				"Content",
 				"Multiple lines."},
 			},
-			expected: `---
-date: Saturday, May 14, 2022
-
-page: test
----
-
-22:34	New log entry
-Content
-Multiple lines.
+			expected: `22:34	New log entry
+	Content
+	Multiple lines.
 `,
 		},
 	}
@@ -91,7 +80,7 @@ Multiple lines.
 	}
 }
 
-func TestGenerateFilename(t *testing.T) {
+func TestLogFilename(t *testing.T) {
 	testDate := time.Date(2022, 5, 14, 22, 34, 16, 0, time.UTC)
 
 	tests := []struct {
@@ -100,18 +89,19 @@ func TestGenerateFilename(t *testing.T) {
 	}{
 		{
 			log:      Log{},
-			expected: "0001-01-01T00:00:00_95c7e5c.log",
+			expected: "01-01-0001.log.md",
 		},
 		{
 			log:      Log{Meta: Meta{Date: testDate}},
-			expected: "2022-05-14T22:34:16_1ee35ca.log",
+			expected: "14-05-2022.log.md",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			if tt.expected != generateFilename(tt.log) {
-				t.Fatal("expected filename did not match actual filename generated")
+			actual := logFilename(tt.log)
+			if tt.expected != actual {
+				t.Fatalf("expected filename \"%s\" did not match actual filename \"%s\"", tt.expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
## Solves
#1 Fix log file format

## Summary

File format is now easier to tab-complete. The format was changed from `<year>-<month>-<day>T<hours>:<minutes>:<seconds>_<hash>.log` to simpler `<day>-<month>-<year>.log.md`.

Log format now also has `.md` suffix for easier usage with different markdown viewers (like `glow`).

Logs are now written by day basis, which means that any log entries composed in one day will be written into a single file. This reduces the noise and amount of log files quite drastically. The metadata information is only written once.

Format was also fixed for git commits so the metadata is not shown in the commit message.

Log format also adds tab's to longer entries with a body so the longer multiline log entries are more readable.

Update `README` log entry example to match the new format and file naming pattern.