### PR TITLE
Add workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,64 @@ Configuration can either be adjusted by manually writing to the caplog config fi
 using config flag option to provide configuration changes through cli.
 
 ```bash
-caplog -c git.local_repository=~/mybook
+caplog -c editor=vim
 ```
 
 User can also provide multiple configuration values at once.
 
 ```bash
-caplog -c git.local_repository=~/mybook -c editor=vim
+caplog -c workspaces=mybook:~/mybook -c editor=vim
+```
+
+### Workspaces
+
+Logs can be stored in multiple git repositories by changing the workspace.
+Available workspaces should be added to the cofiguration file with correct paths.
+
+By default the logs will be stored in `"~/.caplog/capbook"`
+
+Default workspace is always available and can always be set. Default workspace
+cannot be overridden.
+
+#### Adding workspaces
+
+Workspaces can be added by either editing `caplog.toml` configuration file or
+by providing a comma separated list of values to config flag.
+
+Using config flag:
+
+```bash
+caplog -c workspaces=mybook:~/mybook,project:~/project
+```
+
+Or add definition directly to config file:
+
+```toml
+workspaces = [{name = 'mybook', path = '~/mybook'}, {name = 'project', path = '~/project'}]
+```
+
+#### Changing current workspace
+
+Workspace can be changed with three ways. Either by changing the
+`current_workspace` config value itself, by using `--workspace` flag or by
+writing the current workspace directly to config file.
+
+Changing current workspace using config flag:
+
+```bash
+caplog -c current_workspace=mybook
+```
+
+Changing current workspace using workspace flag:
+
+```bash
+caplog -w mybook
+```
+
+Writing directly to config file:
+
+```toml
+current_workspace = 'mybook'
 ```
 
 ### Log storage

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	getDir    = flag.Val("getdir", "g", false, "Returns the local repository directory")
+	dir       = flag.Val("getdir", "g", false, "Returns the local repository directory")
 	page      = flag.Val("page", "p", "", "Saves log entry to <sub-directory>/<page>")
+	workspace = flag.Val("workspace", "w", "", "Changes workspace to given <workspace> if it exists")
 	tags      = flag.Val("tag", "t", TagsFlag{}, "Adds `<tag>` to log entry")
 	setConfig = flag.Val("config", "c", ConfigFlag{}, "Changes config setting with `<key=value>`")
 )
@@ -54,10 +55,19 @@ func Run() error {
 	flag.Usage("caplog")
 	flag.Parse()
 
-	if *getDir {
+	if *dir {
 		// Return current repository path
-		fmt.Println(config.Config.Git.LocalRepository)
+		fmt.Println(config.Config.CurrentWorkspace)
 		return nil
+	}
+
+	if *workspace != "" {
+		fmt.Printf("%+v", config.Config.Workspaces)
+		if exists := config.Config.Workspaces.Has(*workspace); !exists {
+			return fmt.Errorf("given \"%s\" workspace is not a valid workspace\nvalid workspaces are: %v", *workspace, config.Config.Workspaces.Names())
+		}
+
+		return config.Write(map[string]string{config.CurrentWorkspaceKey: *workspace})
 	}
 
 	// Config flags were used needs to do configuration change

--- a/config/config.go
+++ b/config/config.go
@@ -8,12 +8,11 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
-type ConfigKey = string
-
 // Valid configuration keys
 const (
-	GitLocalRepositoryKey ConfigKey = "git.local_repository"
-	EditorKey             ConfigKey = "editor"
+	CurrentWorkspaceKey = "current_workspace"
+	WorkspacesKey       = "workspaces"
+	EditorKey           = "editor"
 )
 
 // Default path location constants
@@ -22,10 +21,13 @@ const (
 	defaultRepositoryPath = "%s/.caplog/capbook"
 )
 
-// Config is exported to give access to existing configuration values
-var Config = config{}
-
 var (
+	// Users home directory
+	HomeDir string
+
+	// Config is exported to give access to existing configuration values
+	Config = config{}
+
 	// In-memory copy of the existing config file
 	configFile []byte
 
@@ -40,24 +42,70 @@ var (
 	}
 )
 
-type gitConfig struct {
-	LocalRepository string `toml:"local_repository,omitempty"`
+type Workspace struct {
+	Name string `toml:"name"`
+	Path string `toml:"path"`
+}
+
+type Workspaces []Workspace
+
+func (w *Workspaces) Append(name string, path string) {
+	*w = append(*w, Workspace{Name: name, Path: path})
+}
+
+func (w Workspaces) Has(workspace string) bool {
+	for _, v := range w {
+		if v.Name == workspace {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (w Workspaces) Names() []string {
+	var n []string
+	for _, v := range w {
+		n = append(n, v.Name)
+	}
+
+	return n
+}
+
+func WorkspacePath() string {
+	return workspacePath(HomeDir, &Config)
+}
+
+func workspacePath(homeDir string, config *config) string {
+	for _, v := range config.Workspaces {
+		if v.Name == config.CurrentWorkspace {
+			return replaceTilde(v.Path, homeDir)
+		}
+	}
+
+	return ""
 }
 
 type config struct {
-	Git    *gitConfig `toml:"git,omitempty"`
-	Editor string     `toml:"editor,omitempty"`
+	CurrentWorkspace string     `toml:"current_workspace,omitempty"`
+	Workspaces       Workspaces `toml:"workspaces,inline,omitempty"`
+	Editor           string     `toml:"editor,omitempty"`
 }
 
 // Load initializes configuration to memory either with default values
 // or read from a `caplog.toml` configuration file if such exists.
-func Load(homeDir string) error {
+func Load() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
 	return load(homeDir, &Config)
 }
 
 // Write writes given map structure to a configuration file
 // located in configuration path
-func Write(c map[ConfigKey]string) error {
+func Write(c map[string]string) error {
 	return writeTo(configPath, c)
 }
 
@@ -73,7 +121,14 @@ func findExistingConfigFile(homeDir string) string {
 }
 
 func load(homeDir string, config *config) error {
-	setDefaults(fmt.Sprintf(defaultRepositoryPath, homeDir), config)
+	HomeDir = homeDir
+
+	defaultPath := fmt.Sprintf(defaultRepositoryPath, homeDir)
+
+	// Set defaults
+
+	config.CurrentWorkspace = "default"
+	config.Editor = "vi"
 
 	configPath = findExistingConfigFile(homeDir)
 
@@ -91,14 +146,44 @@ func load(homeDir string, config *config) error {
 		return err
 	}
 
+	// TODO: make this better, we need to append default workspace here
+	// as that one needs to be always available
+	config.Workspaces.Append("default", defaultPath)
+
+	if exists := config.Workspaces.Has(config.CurrentWorkspace); !exists {
+		return fmt.Errorf("given \"%s\" workspace is not a valid workspace\nvalid workspaces are: %v", config.CurrentWorkspace, config.Workspaces.Names())
+	}
+
 	return nil
 }
 
-func mergeMapToConfig(c map[ConfigKey]string, config *config) error {
+func mergeMapToConfig(c map[string]string, config *config) error {
 	for k, v := range c {
 		switch k {
-		case GitLocalRepositoryKey:
-			config.Git = &gitConfig{LocalRepository: v}
+		case WorkspacesKey:
+			var ws []Workspace
+			wss := strings.Split(v, ",")
+
+			// Accept no value to remove all workspace definitions
+			if len(wss) == 1 && wss[0] == "" {
+				config.Workspaces = ws
+				return nil
+			}
+
+			for _, raw := range wss {
+				rs := strings.SplitN(raw, ":", 2)
+				if len(rs) < 2 {
+					return fmt.Errorf("not enough arguments to set workspaces, set the value with double colon separator \"workspace:path\"")
+				}
+				ws = append(ws, Workspace{Name: rs[0], Path: rs[1]})
+			}
+
+			config.Workspaces = ws
+		case CurrentWorkspaceKey:
+			if exists := config.Workspaces.Has(v); !exists && v != "default" {
+				return fmt.Errorf("given \"%s\" workspace is not a valid workspace\nvalid workspaces are: %v", v, config.Workspaces.Names())
+			}
+			config.CurrentWorkspace = v
 		case EditorKey:
 			config.Editor = v
 		default:
@@ -112,15 +197,9 @@ func replaceTilde(s, r string) string {
 	return strings.Replace(s, "~", r, 1)
 }
 
-func setDefaults(rpath string, c *config) {
-	c.Git = &gitConfig{}
-	c.Git.LocalRepository = rpath
-	c.Editor = "vi"
-}
-
-func writeTo(configPath string, c map[ConfigKey]string) error {
+func writeTo(configPath string, c map[string]string) error {
 	var localConfig config
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
 		if err := toml.Unmarshal(configFile, &localConfig); err != nil {
 			return err
 		}
@@ -135,5 +214,7 @@ func writeTo(configPath string, c map[ConfigKey]string) error {
 		return err
 	}
 
-	return os.WriteFile(configPath, config[:len(config)-1], 0644)
+	trimmed := strings.Trim(string(config), "\n")
+
+	return os.WriteFile(configPath, []byte(trimmed), 0644)
 }

--- a/core/core.go
+++ b/core/core.go
@@ -19,7 +19,7 @@ type Meta struct {
 }
 
 func (m Meta) Location() string {
-	loc := config.Config.Git.LocalRepository
+	loc := config.WorkspacePath()
 
 	if len(m.Page) == 0 {
 		return loc

--- a/main.go
+++ b/main.go
@@ -2,19 +2,13 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/erikjuhani/caplog/cli"
 	"github.com/erikjuhani/caplog/config"
 )
 
 func main() {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if err := config.Load(homeDir); err != nil {
+	if err := config.Load(); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary

#3 Add workspaces

### Config

Remove local repository path in favour of workspaces implementation. Add `Workspace` data structure { Name string, Path string }. Workspaces needs to be a slice in order to work nicely with go-toml.

Add two new configuration options `current_workspace`, which holds the current active workspace name and `workspaces`, which hold all the possible workspaces.

Add new configuration options to `mergeMapToConfig` function parsing.

Update config tests and increase coverage to 87%.

Update `README` accordingly and add new section for workspaces.

### Cmd

Add workspace flag to change workspaces easily.
